### PR TITLE
load model when running predictions results

### DIFF
--- a/gradboost_pv/inference/models.py
+++ b/gradboost_pv/inference/models.py
@@ -456,7 +456,7 @@ class NationalBoostInferenceModel(BaseInferenceModel):
 
         predictions = {}
         for forecast_horizon_hour in self._config.forecast_horizon_hours:
-            logger.debug(f'Running forecast for {forecast_horizon_hour}')
+            logger.debug(f"Running forecast for {forecast_horizon_hour}")
 
             # get model
             model = self.model_loader(forecast_horizon_hour)


### PR DESCRIPTION
# Pull Request

## Description

To save memoery we load each model as we run preidtcions, rather than loading all the models

Fixes #

## How Has This Been Tested?

Ran this locally + CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
