### PR TITLE
interpolate to 30 minutes

### DIFF
--- a/gradboost_pv/save.py
+++ b/gradboost_pv/save.py
@@ -24,8 +24,10 @@ def save_to_database(results_df: pd.DataFrame, start_hour_to_save: int, session:
 
     # interpolate to 30 minutes
     results_df.set_index("datetime_of_target_utc", drop=True, inplace=True)
-    results_df = pd.DataFrame(results_df['forecast_mw'].resample("30T").interpolate(method='linear'))
-    results_df['target_datetime_utc'] = results_df.index
+    results_df = pd.DataFrame(
+        results_df["forecast_mw"].resample("30T").interpolate(method="linear")
+    )
+    results_df["target_datetime_utc"] = results_df.index
 
     logger.debug(results_df[["forecast_mw", "target_datetime_utc"]])
 

--- a/gradboost_pv/save.py
+++ b/gradboost_pv/save.py
@@ -22,6 +22,10 @@ def save_to_database(results_df: pd.DataFrame, start_hour_to_save: int, session:
     results_df["forecast_mw"] = results_df["forecast_kw"]
     results_df["target_datetime_utc"] = results_df["datetime_of_target_utc"]
 
+    # interpolate to 30 minutes
+    results_df = results_df.set_index("target_datetime_utc")
+    results_df = results_df.resample("30T").interpolate()
+
     logger.debug(results_df[["forecast_mw", "target_datetime_utc"]])
 
     forecast_sql = convert_df_to_national_forecast(

--- a/gradboost_pv/save.py
+++ b/gradboost_pv/save.py
@@ -19,12 +19,13 @@ def save_to_database(results_df: pd.DataFrame, start_hour_to_save: int, session:
     """
 
     # TODO fix, wrong units somewhere
-    results_df["forecast_mw"] = results_df["forecast_kw"]
-    results_df["target_datetime_utc"] = results_df["datetime_of_target_utc"]
+    results_df["forecast_mw"] = results_df["forecast_kw"].astype(float)
+    results_df["target_datetime_utc"] = pd.to_datetime(results_df["datetime_of_target_utc"])
 
     # interpolate to 30 minutes
-    results_df = results_df.set_index("target_datetime_utc")
-    results_df = results_df.resample("30T").interpolate()
+    results_df.set_index("datetime_of_target_utc", drop=True, inplace=True)
+    results_df = pd.DataFrame(results_df['forecast_mw'].resample("30T").interpolate(method='linear'))
+    results_df['target_datetime_utc'] = results_df.index
 
     logger.debug(results_df[["forecast_mw", "target_datetime_utc"]])
 

--- a/tests/inference/test_save.py
+++ b/tests/inference/test_save.py
@@ -11,7 +11,7 @@ from nowcasting_datamodel.models import ForecastSQL, ForecastValueSQL, ForecastV
 @freeze_time("2023-01-01")
 def test_save_to_database(db_session):
     results_df = pd.DataFrame(
-        columns=[["datetime_of_target_utc", "forecast_kw"]],
+        columns=["datetime_of_target_utc", "forecast_kw"],
         data=[
             [datetime(2023, 1, 1), 7.3],
             [datetime(2023, 1, 1, 1), 8.3],
@@ -33,7 +33,7 @@ def test_save_to_database_reduce(db_session):
     db_session.query(ForecastSQL).delete()
 
     results_df = pd.DataFrame(
-        columns=[["datetime_of_target_utc", "forecast_kw"]],
+        columns=["datetime_of_target_utc", "forecast_kw"],
         data=[
             [datetime(2023, 1, 1), 7.3],
             [datetime(2023, 1, 1, 1), 8.3],

--- a/tests/inference/test_save.py
+++ b/tests/inference/test_save.py
@@ -22,8 +22,8 @@ def test_save_to_database(db_session):
     save_to_database(session=db_session, results_df=results_df, start_hour_to_save=0)
 
     assert len(db_session.query(ForecastSQL).all()) == 2  # 1 normal, 1 historic
-    assert len(db_session.query(ForecastValueSQL).all()) == 3
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 3
+    assert len(db_session.query(ForecastValueSQL).all()) == 5
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 5
 
 
 @freeze_time("2023-01-01")
@@ -44,5 +44,5 @@ def test_save_to_database_reduce(db_session):
     save_to_database(session=db_session, results_df=results_df, start_hour_to_save=2)
 
     assert len(db_session.query(ForecastSQL).all()) == 2  # 1 normal, 1 historic
-    assert len(db_session.query(ForecastValueSQL).all()) == 3
+    assert len(db_session.query(ForecastValueSQL).all()) == 5
     assert len(db_session.query(ForecastValueLatestSQL).all()) == 1


### PR DESCRIPTION
# Pull Request

## Description

Interpolate data so putput is saved in 30 minute blocks

Fixes #

## How Has This Been Tested?

CI tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
