### PR TITLE
retrain without hcct

### DIFF
--- a/configs/default_production_model.yaml
+++ b/configs/default_production_model.yaml
@@ -42,8 +42,6 @@ required_model_covariates:
   [
     "dswrf_within",
     "dswrf_outer",
-    "hcct_within",
-    "hcct_outer",
     "lcc_within",
     "lcc_outer",
     "t_within",
@@ -51,7 +49,6 @@ required_model_covariates:
     "wdir10_within",
     "wdir10_outer",
     "dswrf_diff",
-    "hcct_diff",
     "lcc_diff",
     "t_diff",
     "wdir10_diff",

--- a/experiments/003_remove_hcct/readme.md
+++ b/experiments/003_remove_hcct/readme.md
@@ -19,4 +19,3 @@ Resutls MAE test set. Should remove HCCT. Later we can investigate if we should 
 | 16      | 0.025 | 0.029                 | 0.025   |
 | 24      | 0.025 | 0.029                 | 0.025   |
 | 36      | 0.026 | 0.029                 | 0.026   |
-

--- a/experiments/003_remove_hcct/readme.md
+++ b/experiments/003_remove_hcct/readme.md
@@ -1,0 +1,22 @@
+# Remove
+
+In live the NWP conusmer only has `hcc` not `hcct` so we need to remove this from the config
+
+Let's compare the results of
+1. training with `hcct` and running inference
+2. training with `hcct` and running inference with no `hcct` data
+3. training with out `hcct`
+
+Resutls MAE test set. Should remove HCCT. Later we can investigate if we should add `hcc` or `mcc`
+
+| Horizon | HCCT  | HCCT not in inference | no HCCT |
+|---------|-------|-----------------------|---------|
+| 0       | 0.016 | 0.019                 | 0.016   |
+| 1       | 0.021 | 0.027                 | 0.021   |
+| 2       | 0.024 | 0.032                 | 0.024   |
+| 4       | 0.025 | 0.031                 | 0.025   |
+| 8       | 0.026 | 0.030                 | 0.026   |
+| 16      | 0.025 | 0.029                 | 0.025   |
+| 24      | 0.025 | 0.029                 | 0.025   |
+| 36      | 0.026 | 0.029                 | 0.026   |
+

--- a/gradboost_pv/models/s3.py
+++ b/gradboost_pv/models/s3.py
@@ -13,7 +13,7 @@ from xgboost import XGBRegressor
 logger = logging.getLogger(__name__)
 
 DEV_BUCKET_NAME = "nowcasting-national-forecaster-models-development"
-MODEL = "v1"
+MODEL = "v2"
 
 
 def build_object_name(forecast_horizon_hour: int) -> str:

--- a/gradboost_pv/preprocessing/region_filtered.py
+++ b/gradboost_pv/preprocessing/region_filtered.py
@@ -22,7 +22,7 @@ ESO_GEO_JSON_URL = (
 # processing takes quite a long time, so take a subset for now.
 DEFAULT_VARIABLES_FOR_PROCESSING = [
     "dswrf",
-    "hcct",
+    # "hcct",
     "lcc",
     "t",
     # "sde",


### PR DESCRIPTION
# Pull Request

## Description

Remove hcct as its not in training data. looked at inference with nans of `hcct`
added new models to v2 in s3

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
