### PR TITLE
pandas==1.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pandas
+pandas==1.5.3
 xarray
 xgboost
 ocf_datapipes


### PR DESCRIPTION
# Pull Request

## Description

- Funny behaviour between `0.1.27`  and `0.1.28`. `0.1.28` does not work. 
- restricted to pandas==1.5.3


Fixes #

## How Has This Been Tested?

Tested app locally with pandas==1.5.3

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
